### PR TITLE
Allow setting ID and CreatedAt values with Admin Create Identity API

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,6 +30,10 @@ steps:
           docker push gcr.io/onx-staging/kratosx:latest
         fi
 
+        if [[ "$BRANCH_NAME" == "production" ]]; then
+          docker push gcr.io/onx-production/kratosx:latest
+        fi
+
         if [[ "$BRANCH_NAME" == "master" ]]; then
           docker push gcr.io/onx-daily/kratosx:latest
           docker push gcr.io/onx-staging/kratosx:latest

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,40 @@
+steps:
+  # build
+  - id: 'docker build'
+    name: 'gcr.io/cloud-builders/docker'
+    waitFor: ['-']
+    args: [
+      'build',
+      '-f', '.docker/Dockerfile-build',
+      '--build-arg=COMMIT=$(COMMIT_SHA)',
+      '--build-arg=BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")',
+      '-t', 'gcr.io/onx-daily/kratosx:latest',
+      '-t', 'gcr.io/onx-staging/kratosx:latest',
+      '-t', 'gcr.io/onx-production/kratosx:latest',
+      '.'
+    ]
+
+  # push
+  - id: 'docker push'
+    name: 'gcr.io/cloud-builders/docker'
+    waitFor: ['docker build']
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if [[ "$BRANCH_NAME" == "daily" ]]; then
+          docker push gcr.io/onx-daily/kratosx:latest
+        fi
+
+        if [[ "$BRANCH_NAME" == "staging" ]]; then
+          docker push gcr.io/onx-staging/kratosx:latest
+        fi
+
+        if [[ "$BRANCH_NAME" == "master" ]]; then
+          docker push gcr.io/onx-daily/kratosx:latest
+          docker push gcr.io/onx-staging/kratosx:latest
+          docker push gcr.io/onx-production/kratosx:latest
+        fi
+
+tags:
+  - kratosx

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,8 @@ steps:
   - id: 'docker build'
     name: 'gcr.io/cloud-builders/docker'
     waitFor: ['-']
+    env:
+    - DOCKER_BUILDKIT=1
     args: [
       'build',
       '-f', '.docker/Dockerfile-build',
@@ -23,7 +25,7 @@ steps:
       - '-c'
       - |
         if [[ "$BRANCH_NAME" == "daily" ]]; then
-          docker push gcr.io/onx-daily/kratosx:latest
+          docker push gcr.io/onx-daily/kratosx:v0.10.1
         fi
 
         if [[ "$BRANCH_NAME" == "staging" ]]; then
@@ -34,7 +36,7 @@ steps:
           docker push gcr.io/onx-production/kratosx:latest
         fi
 
-        if [[ "$BRANCH_NAME" == "master" ]]; then
+        if [[ "$BRANCH_NAME" == "0.10.1" ]]; then
           docker push gcr.io/onx-daily/kratosx:latest
           docker push gcr.io/onx-staging/kratosx:latest
           docker push gcr.io/onx-production/kratosx:latest

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/ory/kratos/hash"
 
 	"github.com/ory/kratos/x"
@@ -213,6 +214,11 @@ type AdminCreateIdentityBody struct {
 	// required: true
 	SchemaID string `json:"schema_id"`
 
+	// ID is the identity's unique identifier.
+	//
+	// required: false
+	ID *uuid.UUID `json:"id,omitempty"`
+
 	// Traits represent an identity's traits. The identity is able to create, modify, and delete traits
 	// in a self-service manner. The input will always be validated against the JSON Schema defined
 	// in `schema_url`.
@@ -250,6 +256,11 @@ type AdminCreateIdentityBody struct {
 	//
 	// required: false
 	State State `json:"state"`
+
+	// CreatedAt represents the time this identity was initially created.
+	//
+	// required: false
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 }
 
 // swagger:model adminIdentityImportCredentials
@@ -351,6 +362,14 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 		RecoveryAddresses:   cr.RecoveryAddresses,
 		MetadataAdmin:       []byte(cr.MetadataAdmin),
 		MetadataPublic:      []byte(cr.MetadataPublic),
+	}
+
+	if cr.ID != nil {
+		i.ID = *cr.ID
+	}
+
+	if cr.CreatedAt != nil {
+		i.CreatedAt = *cr.CreatedAt
 	}
 
 	if err := h.importCredentials(r.Context(), i, cr.Credentials); err != nil {


### PR DESCRIPTION
- admin create with ID and CreatedAt, if specified and valid
- add cloudbuild steps